### PR TITLE
Use env vars for API tokens

### DIFF
--- a/News2Docx_CLI.py
+++ b/News2Docx_CLI.py
@@ -56,7 +56,7 @@ from ai_processor import (
     process_articles_concurrent, process_articles_with_two_steps,
     process_articles_to_words, count_english_words, safe_filename,
     handle_error, safe_execute, now_stamp,
-    DEFAULT_MODEL_ID, DEFAULT_SILICONFLOW_API_KEY, DEFAULT_SILICONFLOW_URL,  # 修正常量名
+    DEFAULT_MODEL_ID, DEFAULT_SILICONFLOW_URL,  # 修正常量名
     DEFAULT_BATCH_SIZE, DEFAULT_MAX_TOKENS_HARD_CAP, DEFAULT_USE_TWO_STEP,
     DEFAULT_CONCURRENCY, CHINESE_VARIANT_HINT, SEPARATOR_LINE, MAIN_SEPARATOR,
     TAG_RE, PARA_TAG_RE,
@@ -1068,12 +1068,29 @@ def main() -> None:
     """命令行入口函数，解析参数并运行完整流程"""
     import Scraper
     ap = Scraper.build_arg_parser()
+    ap.add_argument("--siliconflow-api-key", default=os.getenv("SILICONFLOW_API_KEY", None))
+    ap.add_argument("--config", help="JSON配置文件，提供API密钥", default=None)
     args = ap.parse_args()
+
+    config_data = {}
+    if args.config:
+        with open(args.config, "r", encoding="utf-8") as f:
+            config_data = json.load(f)
+
+    api_token = args.api_token or config_data.get("crawler_api_token") or os.getenv("CRAWLER_API_TOKEN")
+    silicon_key = args.siliconflow_api_key or config_data.get("siliconflow_api_key") or os.getenv("SILICONFLOW_API_KEY")
+
+    if not api_token:
+        raise ValueError("CRAWLER_API_TOKEN is required. Provide via --api-token, config file, or env variable.")
+    if not silicon_key:
+        raise ValueError("SILICONFLOW_API_KEY is required. Provide via --siliconflow-api-key, config file, or env variable.")
+
+    os.environ["SILICONFLOW_API_KEY"] = silicon_key
 
     cfg = ScrapeConfig(
         output_dir=args.output_dir,
         api_url=args.api_url,
-        api_token=args.api_token,
+        api_token=api_token,
         max_urls=max(1, args.max_urls),
         concurrency=max(1, args.concurrency),
         retry_interval_hours=max(1, args.retry_hours),
@@ -1292,6 +1309,8 @@ def build_scraper_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--output-dir", default=os.getenv("CRAWLER_OUTPUT_DIR", ""))
     p.add_argument("--api-url", default=os.getenv("CRAWLER_API_URL", None))
     p.add_argument("--api-token", default=os.getenv("CRAWLER_API_TOKEN", None))
+    p.add_argument("--siliconflow-api-key", default=os.getenv("SILICONFLOW_API_KEY", None))
+    p.add_argument("--config", help="JSON配置文件，提供API密钥", default=None)
     p.add_argument("--max-urls", type=int, default=int(os.getenv("CRAWLER_MAX_URLS", "10")))
     p.add_argument("--concurrency", type=int, default=int(os.getenv("CRAWLER_CONCURRENCY", str(DEFAULT_CONCURRENCY))))
     p.add_argument("--retry-hours", type=int, default=int(os.getenv("CRAWLER_RETRY_HOURS", "24")))
@@ -1312,6 +1331,20 @@ def main_with_scraper() -> None:
     """使用Scraper模块的命令行入口函数"""
     ap = build_scraper_arg_parser()
     args = ap.parse_args()
+    config_data = {}
+    if args.config:
+        with open(args.config, "r", encoding="utf-8") as f:
+            config_data = json.load(f)
+
+    api_token = args.api_token or config_data.get("crawler_api_token") or os.getenv("CRAWLER_API_TOKEN")
+    silicon_key = args.siliconflow_api_key or config_data.get("siliconflow_api_key") or os.getenv("SILICONFLOW_API_KEY")
+
+    if not api_token:
+        raise ValueError("CRAWLER_API_TOKEN is required. Provide via --api-token, config file, or env variable.")
+    if not silicon_key:
+        raise ValueError("SILICONFLOW_API_KEY is required. Provide via --siliconflow-api-key, config file, or env variable.")
+
+    os.environ["SILICONFLOW_API_KEY"] = silicon_key
 
     # 动态导入Scraper模块
     import Scraper
@@ -1319,7 +1352,7 @@ def main_with_scraper() -> None:
     cfg = Scraper.ScrapeConfig(
         output_dir=args.output_dir,
         api_url=args.api_url,
-        api_token=args.api_token,
+        api_token=api_token,
         max_urls=max(1, args.max_urls),
         concurrency=max(1, args.concurrency),
         retry_interval_hours=max(1, args.retry_hours),

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
+# News2Docx
 
+## Environment Variables
+
+The application requires API credentials to be provided via environment variables, command line arguments, or a JSON configuration file.
+
+- `CRAWLER_API_TOKEN` – Token for the crawler API.
+- `SILICONFLOW_API_KEY` – API key for the SiliconFlow service.
+
+Example:
+
+```bash
+export CRAWLER_API_TOKEN="your_crawler_token"
+export SILICONFLOW_API_KEY="your_siliconflow_key"
+```
+
+You may also pass these values using the command line options `--api-token` and `--siliconflow-api-key` or supply a JSON config file via `--config` with fields `crawler_api_token` and `siliconflow_api_key`.

--- a/Scraper.py
+++ b/Scraper.py
@@ -43,7 +43,6 @@ from unified_logger import (
 
 # API配置
 DEFAULT_CRAWLER_API_URL = "https://gdelt-xupojkickl.cn-hongkong.fcapp.run"
-DEFAULT_CRAWLER_API_TOKEN = "token-7eiac9018c346ge9c93ef25266ai"
 
 # 文件和路径配置
 DEFAULT_OUTPUT_DIR = ""
@@ -119,7 +118,7 @@ class ScrapeConfig:
     """新闻爬虫配置类"""
     output_dir: str = DEFAULT_OUTPUT_DIR
     api_url: str = os.getenv("CRAWLER_API_URL", DEFAULT_CRAWLER_API_URL)
-    api_token: str = os.getenv("CRAWLER_API_TOKEN", DEFAULT_CRAWLER_API_TOKEN)
+    api_token: Optional[str] = field(default_factory=lambda: os.getenv("CRAWLER_API_TOKEN"))
     scraped_urls_file: str = DEFAULT_SCRAPED_URLS_FILE
     failed_urls_file: str = DEFAULT_FAILED_URLS_FILE
     retry_interval_hours: int = DEFAULT_RETRY_INTERVAL_HOURS
@@ -145,6 +144,12 @@ class ScrapeConfig:
     random_seed: Optional[int] = (
         int(os.getenv("CRAWLER_RANDOM_SEED")) if os.getenv("CRAWLER_RANDOM_SEED") else None
     )
+
+    def __post_init__(self) -> None:
+        if not self.api_token:
+            raise ValueError(
+                "CRAWLER_API_TOKEN is required. Set environment variable or pass --api-token"
+            )
 
 
 @dataclass
@@ -1080,10 +1085,16 @@ def main() -> None:
     ap = build_arg_parser()
     args = ap.parse_args()
 
+    api_token = args.api_token or os.getenv("CRAWLER_API_TOKEN")
+    if not api_token:
+        raise ValueError(
+            "CRAWLER_API_TOKEN is required. Set environment variable or use --api-token"
+        )
+
     cfg = ScrapeConfig(
         output_dir=args.output_dir,
         api_url=args.api_url or DEFAULT_CRAWLER_API_URL,
-        api_token=args.api_token or DEFAULT_CRAWLER_API_TOKEN,
+        api_token=api_token,
         max_urls=max(1, args.max_urls),
         concurrency=max(1, args.concurrency),
         retry_interval_hours=max(1, args.retry_hours),

--- a/ai_processor.py
+++ b/ai_processor.py
@@ -46,11 +46,9 @@ from unified_logger import (
 
 # API配置
 DEFAULT_MODEL_ID = os.environ.get("SILICONFLOW_MODEL", "THUDM/glm-4-9b-chat")
-DEFAULT_SILICONFLOW_API_KEY = "sk-uxbxbsykbjkvvndwycojnnzdngyqcwpvldgczgljuqklsjas"
 DEFAULT_SILICONFLOW_URL = "https://api.siliconflow.cn/v1/chat/completions"
 
 # 兼容性别名
-DEFAULT_OPENROUTER_API_KEY = DEFAULT_SILICONFLOW_API_KEY
 DEFAULT_OPENROUTER_URL = DEFAULT_SILICONFLOW_URL
 
 # 性能配置
@@ -240,7 +238,7 @@ def build_translation_prompts(text: str, target_lang: str = "Chinese") -> Tuple[
 
 
 def call_ai_api(system_prompt: str, user_prompt: str, model: str = DEFAULT_MODEL_ID,
-                api_key: str = DEFAULT_SILICONFLOW_API_KEY, url: str = DEFAULT_SILICONFLOW_URL,
+                api_key: Optional[str] = None, url: str = DEFAULT_SILICONFLOW_URL,
                 max_tokens: int = None) -> Optional[str]:
     """调用AI API的通用函数
 
@@ -255,8 +253,9 @@ def call_ai_api(system_prompt: str, user_prompt: str, model: str = DEFAULT_MODEL
     Returns:
         Optional[str]: AI响应内容，失败返回None
     """
+    api_key = api_key or os.getenv("SILICONFLOW_API_KEY")
     if not api_key:
-        raise RuntimeError("API key is empty")
+        raise RuntimeError("SILICONFLOW_API_KEY is required. Set env or pass api_key")
 
     if max_tokens is None:
         max_tokens = estimate_max_tokens(1)
@@ -946,12 +945,13 @@ def backoff_sleep(attempt: int):
 
 def call_siliconflow_tagged_output(title_content_block: str, start_i: int, word_target: str = "300-350") -> str:
     """调用硅基流动 API 生成带标签的输出"""
-    if not DEFAULT_SILICONFLOW_API_KEY:
+    api_key = os.getenv("SILICONFLOW_API_KEY")
+    if not api_key:
         raise RuntimeError("SILICONFLOW_API_KEY is empty. Set environment variable before running.")
     payload_prompts = build_system_and_user_prompt(title_content_block, start_i, word_target)
 
     headers = {
-        "Authorization": f"Bearer {DEFAULT_SILICONFLOW_API_KEY}",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
     }
 
@@ -1076,8 +1076,12 @@ def repair_summary_if_too_short(article: Article, draft_content: str, target_wor
 
 请输出扩展后的完整内容："""
 
+    api_key = os.getenv("SILICONFLOW_API_KEY")
+    if not api_key:
+        raise RuntimeError("SILICONFLOW_API_KEY is empty. Set environment variable before running.")
+
     headers = {
-        "Authorization": f"Bearer {DEFAULT_SILICONFLOW_API_KEY}",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
     }
 


### PR DESCRIPTION
## Summary
- remove hardcoded API tokens from scraper and AI processor
- load CRAWLER_API_TOKEN and SILICONFLOW_API_KEY from environment or CLI/config
- document required env vars

## Testing
- `python -m py_compile Scraper.py ai_processor.py News2Docx_CLI.py`


------
https://chatgpt.com/codex/tasks/task_e_68bff127e6f88321b8eb8b626a1fc2e7